### PR TITLE
Add docker containerization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Build output
+target/
+JAR/
+jar/
+lib/
+
+# VCS / CI
+.git/
+.github/
+
+# IDE
+.idea/
+.settings/
+*.iml
+.classpath
+.project
+
+# Docs and static client (the server only exposes the API)
+doc/
+html_client/
+
+# OS junk
+.DS_Store
+
+# Local samples / scratch
+sample.json
+*.log
+test.ttl

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,54 @@
+name: FOOPS! - Build and push Docker image
+
+on:
+  push:
+    branches: [ "main" ]
+    tags: [ "v*.*.*" ]   # also publish on release tags, e.g. v0.4.0
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    # Add these in the repo: Settings > Secrets and variables > Actions
+    #   DOCKERHUB_USERNAME -> your Docker Hub username
+    #   DOCKERHUB_TOKEN    -> a Docker Hub access token (Account Settings > Security)
+    env:
+      IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/foops
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract image metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          # Add linux/arm64 below for a multi-arch image (slower build).
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+
+# ---- Build stage ----------------------------------------------------------
+# Builds the Spring Boot server JAR from the default pom.xml.
+# JDK 11 matches the version the project was built and tested with.
+FROM maven:3.9-eclipse-temurin-11 AS build
+WORKDIR /app
+
+# Resolve dependencies first so they are cached as long as pom.xml is unchanged.
+COPY pom.xml ./
+RUN mvn -B dependency:go-offline
+
+# Build the application (tests are skipped: several of them hit the network).
+COPY src ./src
+RUN mvn -B clean package -DskipTests
+
+# ---- Runtime stage --------------------------------------------------------
+FROM eclipse-temurin:11-jre-jammy
+WORKDIR /app
+
+# Run as an unprivileged user.
+RUN groupadd --system foops && useradd --system --gid foops foops
+
+# Spring Boot repackages FOOPSServerApplication as the executable JAR.
+COPY --from=build /app/target/fair_ontologies-*.jar app.jar
+
+# Port the server listens on inside the container (Spring Boot default).
+ENV SERVER_PORT=8080
+ENV JAVA_OPTS=""
+EXPOSE 8080
+
+USER foops
+
+# exec so the JVM is PID 1 and receives stop signals directly.
+ENTRYPOINT ["sh", "-c", "exec java ${JAVA_OPTS} -Dserver.port=${SERVER_PORT} -jar app.jar"]

--- a/README.md
+++ b/README.md
@@ -65,6 +65,37 @@ curl -X POST "http://localhost:8083/assessOntology" -H "accept: application/json
 ### Swagger OpenAPI
 When you run the server, FOOPS! will set up a Swagger UI describing the endpoints available in the API. This API is available at `http://localhost:PORT/swagger-ui/index.html#/`
 
+## Running the server with Docker
+A `Dockerfile` is provided so you don't need a local JDK or Maven installation. The image is built in two stages: the first stage compiles the Spring Boot JAR, and the second stage runs it on a slim JRE.
+
+### Using Docker directly
+Build the image:
+
+```
+docker build -t foops .
+```
+
+Run the container (maps host port 8083 to the server's port 8080 inside the container):
+
+```
+docker run --rm -p 8083:8080 foops
+```
+
+### Using Docker Compose
+A `docker-compose.yml` is also included. To build and start the server:
+
+```
+docker compose up --build
+```
+
+The server will be available on `http://localhost:8083`. Test it with the same `curl` command shown above:
+
+```
+curl -X POST "http://localhost:8083/assessOntology" -H "accept: application/json;charset=UTF-8" -H "Content-Type: application/json;charset=UTF-8" -d "{ \"ontologyUri\": \"https://w3id.org/okn/o/sd\"}"
+```
+
+The port the server listens on inside the container can be changed with the `SERVER_PORT` environment variable, and extra JVM options can be passed with `JAVA_OPTS`.
+
 
 ## Running the JAR in local
 To create the JAR, just run:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  foops:
+    build: .
+    image: foops:latest
+    container_name: foops
+    ports:
+      # host:container -> 8083 matches the examples in the README
+      - "8083:8080"
+    environment:
+      - SERVER_PORT=8080
+      # - JAVA_OPTS=-Xmx1g
+    restart: unless-stopped


### PR DESCRIPTION
Adds Docker support to FOOPS! so that the server can be built and run without a local JDK/Maven install, plus a CI workflow that publishes the image to Docker Hub.

  ## How to run

  ```bash
  docker compose up --build      

  docker build -t foops .
  docker run --rm -p 8083:8080 foops
```
  Port is configurable via SERVER_PORT, extra JVM flags via JAVA_OPTS.

  Required before the publish workflow works

  Add two repo secrets (Settings → Secrets and variables → Actions):
  - DOCKERHUB_USERNAME — Docker Hub username
  - DOCKERHUB_TOKEN — Docker Hub access token